### PR TITLE
Create parent dir before creating tmp dockerfile

### DIFF
--- a/app/core/task.py
+++ b/app/core/task.py
@@ -198,6 +198,7 @@ def create_running_container(
         tmp_dockerfile = "{}/Dockerfile-{}-{}".format(
             dir_info["local"]["setup"], repair_tool.name, bug_image_id
         )
+        os.makedirs(dirname(tmp_dockerfile), exist_ok=True)
         with open(tmp_dockerfile, "w") as dock_file:
             dock_file.write("FROM {}\n".format(repair_tool.image_name))
             dock_file.write("ADD . {0}\n".format(dir_info["container"]["setup"]))


### PR DESCRIPTION
to reproduce the error: delete the docker image named `jkali-defects4j-lang-51`, delete `benchmark/defects4j/Lang/51`, run `./bin/cerberus repair -t jkali -b defects4j --profile-list C5 --bug-index-list 651 --debug`