### PR TITLE
change url of benchmark/efffix to avoid permission denied

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -39,7 +39,7 @@
 	url = https://github.com/nus-apr/saver-benchmark
 [submodule "benchmark/efffix"]
 	path = benchmark/efffix
-	url = git@github.com:nus-apr/effFix-benchmark.git
+	url = https://github.com/nus-apr/effFix-benchmark.git
 [submodule "benchmark/vul4j"]
 	path = benchmark/vul4j
 	url = https://github.com/nus-apr/vul4j.git


### PR DESCRIPTION
Cerberus is configuring the URL of the benchmark/efffix using SSH, which can often result in "permission denied" errors. I think it would be better to switch to using HTTPS URL instead. I have noticed that you have made this change for other benchmarks as well.