### PR TITLE
Update recoder to use cpu and reduce hardcoding

### DIFF
--- a/app/drivers/benchmarks/java/Defects4J.py
+++ b/app/drivers/benchmarks/java/Defects4J.py
@@ -28,7 +28,7 @@ class Defects4J(AbstractBenchmark):
     def deploy(self, bug_index, container_id):
         self.emit_normal("downloading experiment subject")
         experiment_item = self.experiment_subjects[bug_index - 1]
-        bug_id = str(experiment_item[self.key_bug_id])
+        bug_id = str(experiment_item[self.key_bug_id]).split('-')[1]
         custom_env = {"JAVA_TOOL_OPTIONS": "-Dfile.encoding=UTF8"}
         command_str = "defects4j checkout -p {} -v {}b -w {}".format(
             experiment_item[self.key_subject],

--- a/app/drivers/tools/repair/java/Recoder.py
+++ b/app/drivers/tools/repair/java/Recoder.py
@@ -27,8 +27,8 @@ class Recoder(AbstractRepairTool):
 
         timeout_h = str(repair_config_info[self.key_timeout])
 
-        # if not self.use_gpu:
-        #     self.error_exit("cannot run Recorder without a GPU")
+        if len(bug_info[self.key_fix_lines]) == 0:
+            self.error_exit("no line number to fix")
 
         self.bug_name = bug_info[self.key_bug_id]
         file = (

--- a/app/drivers/tools/repair/java/Recoder.py
+++ b/app/drivers/tools/repair/java/Recoder.py
@@ -31,8 +31,6 @@ class Recoder(AbstractRepairTool):
         #     self.error_exit("cannot run Recorder without a GPU")
 
         self.bug_name = bug_info[self.key_bug_id]
-        self.full_bug_name = "{}-{}".format(bug_info[self.key_subject],
-                                            bug_info[self.key_bug_id])
         file = (
             join(
                 bug_info[self.key_dir_source],
@@ -43,7 +41,7 @@ class Recoder(AbstractRepairTool):
         if self.use_gpu:
             recorder_command = "bash -c 'export PATH=$PATH:/root/defects4j/framework/bin && timeout -k 5m {}h python3 inference.py --bug_id {} --class_name {} --buggy_file {} --buggy_line {} --use_gpu'".format(  # currently supporting only defects4j
                 timeout_h,
-                self.full_bug_name,
+                self.bug_name,
                 bug_info[self.key_fix_file],
                 join(self.dir_expr, "src", file),
                 bug_info[self.key_fix_lines][0]
@@ -51,7 +49,7 @@ class Recoder(AbstractRepairTool):
         else:
             recorder_command = "bash -c 'export PATH=$PATH:/root/defects4j/framework/bin && timeout -k 5m {}h python3 inference.py --bug_id {} --class_name {} --buggy_file {} --buggy_line {}'".format(  # currently supporting only defects4j
                 timeout_h,
-                self.full_bug_name,
+                self.bug_name,
                 bug_info[self.key_fix_file],
                 join(self.dir_expr, "src", file),
                 bug_info[self.key_fix_lines][0]
@@ -62,7 +60,7 @@ class Recoder(AbstractRepairTool):
 
         recorder_command = "bash -c 'export PATH=$PATH:/root/defects4j/framework/bin && timeout -k 5m {}h python3 validate.py --bug_id {} --patch_info patch/{}-{} --dir {} --buggy_file {}'".format(
             timeout_h,
-            self.full_bug_name,
+            self.bug_name,
             bug_info[self.key_subject],
             bug_info[self.key_bug_id],
             join(self.dir_expr, "src"), 
@@ -126,7 +124,7 @@ class Recoder(AbstractRepairTool):
 
         if not self.stats.error_stats.is_error:
             self.run_command(
-                "cp /root/Repair/patches/{}patch.txt /output/".format(self.full_bug_name)
+                "cp /root/Repair/patches/{}patch.txt /output/".format(self.bug_name)
             )
             self.stats.patches_stats.generated = 1
             self.stats.patches_stats.enumerations = 1


### PR DESCRIPTION
Hi,

In this pull request, I have implemented several changes to enhance Recoder's functionality:

1. Enabled CPU usage: Recoder can now utilize the CPU for its operations;
2. Utilized meta-data from the meta-data.json file of Defects4J: Recoder now retrieves the necessary meta-data from the provided meta-data.json file instead of relying on its own meta-data;
3. Improved patch generation termination handling: Recoder is now capable of saving generated patches even when the patch generation process is force-terminated due to a timeout;

Regarding resource usage, the memory consumption of Cerberus remains within reasonable limits. For each bug, it utilizes less than 200MB of virtual memory (VIRT) and less than 100MB of physical memory (RES).

However, it's important to note that using Recoder with CPU can result in significant overhead time, particularly when the number of available CPU cores is limited. With only 2 CPU cores, patch generation takes approximately 30 minutes. However, this time is reduced to around 5 minutes when utilizing 16 CPU cores.

Please review the changes made in this pull request and let me know your feedback.