### PR TITLE
change from with "--runtime=nvidia" to with "--gpus all"

### DIFF
--- a/app/core/container.py
+++ b/app/core/container.py
@@ -271,7 +271,7 @@ def build_container(
             "privileged": True,
             "cpuset_cpus": cpu,
             "tty": True,
-            "runtime": "nvidia" if values.use_gpu else "runc",
+            "device_requests": [docker.types.DeviceRequest(count=-1, capabilities=[['gpu']])] if values.use_gpu else False,
         }
 
         default_mem_limit = "32g"

--- a/app/core/container.py
+++ b/app/core/container.py
@@ -271,7 +271,7 @@ def build_container(
             "privileged": True,
             "cpuset_cpus": cpu,
             "tty": True,
-            "device_requests": [docker.types.DeviceRequest(count=-1, capabilities=[['gpu']])] if values.use_gpu else False,
+            "device_requests": [docker.types.DeviceRequest(count=-1, capabilities=[['gpu']])] if values.use_gpu else [],
         }
 
         default_mem_limit = "32g"


### PR DESCRIPTION
When utilizing Docker with the runtime option, we can encounter the following error message: "docker: Error response from daemon: Unknown runtime specified nvidia" (Refer to examples in this [issue](https://github.com/NVIDIA/nvidia-docker/issues/838)). To resolve this issue, you can implement a solution provided in this [comment](https://github.com/docker/docker-py/issues/2395#issuecomment-907243275), which involves making changes to the command by using "--gpus all" instead. 