### PR TITLE
Update java drivers & vul4j benchmark

### DIFF
--- a/app/drivers/benchmarks/java/Vul4J.py
+++ b/app/drivers/benchmarks/java/Vul4J.py
@@ -104,53 +104,19 @@ class Vul4J(AbstractBenchmark):
         self.emit_normal("compress experiment subject's dependencies")
         experiment_item = self.experiment_subjects[bug_index - 1]
         build_system = experiment_item[self.key_build_system]
-        set_java_home_cmd = "JAVA_HOME=$JAVA{0}_HOME".format(
-            experiment_item[self.key_java_version]
-        )
-
+        dir_classes = join(self.dir_expr, "src", experiment_item[self.key_dir_class])
+        dir_target = "/".join(dir_classes.split("/")[:-1])
         if build_system != "maven":
             return True
-
-        command_str = "bash -c '{0} mvn dependency:copy-dependencies'".format(
-            set_java_home_cmd
+        
+        self.log_compress_path = (
+            self.dir_logs + "/" + self.name + "-" + str(bug_index) + "-compress.log"
         )
+
+        command_str = f"bash compress_deps {dir_target}"
         status = self.run_command(
-            container_id,
-            command_str,
-            self.log_build_path,
-            join(
-                self.dir_expr,
-                "src",
-                experiment_item[self.key_fail_mod_dir],
-            ),
+            container_id, command_str, self.log_compress_path, self.dir_setup
         )
-
-        if status != 0:
-            command_str = "bash -c 'mvn dependency:copy-dependencies'"
-            status = self.run_command(
-                container_id,
-                command_str,
-                self.log_build_path,
-                join(
-                    self.dir_expr,
-                    "src",
-                    experiment_item[self.key_fail_mod_dir],
-                ),
-            )
-
-            if status != 0:
-                return False
-
-        command_str = "bash -c '{0} {1}'".format(
-            join(self.dir_expr, "base", "init_dependencies.sh"),
-            join(
-                self.dir_expr,
-                "src",
-                experiment_item[self.key_fail_mod_dir],
-                "target",
-            ),
-        )
-        status = self.run_command(container_id, command_str, self.log_build_path)
 
         return status == 0
 

--- a/app/drivers/tools/repair/java/ARJA.py
+++ b/app/drivers/tools/repair/java/ARJA.py
@@ -17,7 +17,7 @@ class ARJA(AbstractRepairTool):
     def __init__(self) -> None:
         self.name = os.path.basename(__file__)[:-3].lower()
         super().__init__(self.name)
-        self.image_name = "rshariffdeen/arja"
+        self.image_name = "hzhenxin/arja"
 
     def invoke(
         self, bug_info: Dict[str, Any], task_config_info: Dict[str, Any]
@@ -53,35 +53,6 @@ class ARJA(AbstractRepairTool):
             join(self.arja_home, "external", "lib", "hamcrest-core-1.3.jar")
         )
         list_deps.append(join(self.arja_home, "external", "lib", "junit-4.11.jar"))
-        if bug_info[self.key_build_system] == "maven":
-            self.run_command(
-                f"mvn dependency:copy-dependencies",
-                dir_path=join(self.dir_expr, "src"),
-                env=env,
-            )
-            failing_mod = bug_info.get("failing_module", "")
-            # Add common folders for deependencies
-            list_deps += [
-                x
-                for x in self.list_dir(
-                    join(self.dir_expr, "src", failing_mod, "target", "dependency")
-                )
-                if x.endswith(".jar") and not "junit" in x
-            ]
-            list_deps += [
-                x
-                for x in self.list_dir(
-                    join(
-                        self.dir_expr,
-                        "src",
-                        failing_mod,
-                        "test",
-                        "target",
-                        "dependency",
-                    )
-                )
-                if x.endswith(".jar") and not "junit" in x
-            ]
         list_deps_str = ":".join(list_deps)
 
         arja_default_population_size = 40

--- a/app/drivers/tools/repair/java/ARJA_E.py
+++ b/app/drivers/tools/repair/java/ARJA_E.py
@@ -19,7 +19,7 @@ class ARJA_E(AbstractRepairTool):
     def __init__(self) -> None:
         self.name = os.path.basename(__file__)[:-3].lower()
         super().__init__(self.name)
-        self.image_name = "rshariffdeen/arjae"
+        self.image_name = "hzhenxin/arjae"
 
     def invoke(
         self, bug_info: Dict[str, Any], task_config_info: Dict[str, Any]
@@ -61,36 +61,6 @@ class ARJA_E(AbstractRepairTool):
             join(self.arja_e_home, "external", "lib", "hamcrest-core-1.3.jar"),
             join(self.arja_e_home, "external", "lib", "junit-4.12.jar"),
         ]
-        # Ensure the dependencies exist
-        if bug_info[self.key_build_system] == "maven":
-            failing_mod = bug_info.get("failing_module", "")
-            self.run_command(
-                f"mvn dependency:copy-dependencies",
-                dir_path=join(self.dir_expr, "src", failing_mod),
-                env=env,
-            )
-            # Add common folders for deependencies
-            list_deps += [
-                x
-                for x in self.list_dir(
-                    join(self.dir_expr, "src", failing_mod, "target", "dependency")
-                )
-                if x.endswith(".jar") and not "junit" in x
-            ]
-            list_deps += [
-                x
-                for x in self.list_dir(
-                    join(
-                        self.dir_expr,
-                        "src",
-                        failing_mod,
-                        "test",
-                        "target",
-                        "dependency",
-                    )
-                )
-                if x.endswith(".jar") and not "junit" in x
-            ]
 
         list_deps_str = ":".join(list_deps)
         dir_localization = f"{self.dir_output}/localization"

--- a/app/drivers/tools/repair/java/TBar.py
+++ b/app/drivers/tools/repair/java/TBar.py
@@ -159,8 +159,6 @@ class TBar(AbstractRepairTool):
             "FailedTestCases/",
             f"{bug_id_str}.txt",
         )
-        # Temporary: copying modified FL.sh
-        self.run_command(f"cp {self.dir_setup}FL.sh {self.tbar_root_dir}")
         # Specifying failing module
         failing_module = bug_info.get("failing_module", "")
         


### PR DESCRIPTION
## Description

 Included description for the changes in the respective tool repo.

### Vul4j Benchmark

- Modified to compress maven subject depedencies into `all-dependencies.jar`.  

### ARJA_E/ARJA

- Update with new tool image. Changes in Arja Tool [0fcef1e](https://github.com/rshariffdeen/arja/commit/0fcef1ef1b569b85af146de42406259a97568c37).
 
      fixes #182  (`InheritingIO in ProcessBuilder to prevent full output buffer blocking the process`)

      fixes #188 (`Rebuilt Gzoltar with changes in` [3edabad](https://github.com/Marti2203/gzoltar/commit/3edabad4eb88e4fd448d73ed45968c483df886bf)).

- Remove command to perform mvn copy:dependencies. All dependencies shall be compressed by benchmark into one jar.
fixes #185. 
    1. No longer need to account for falling module in the tool driver. 
    2. Conflicting Junit is removed during compression of dependencies. See [5f99b1d](https://github.com/nus-apr/vul4j/commit/5f99b1dd5a654a0e7e23f364f740932d14dc5277) for `compress_deps`.

### TBar

-  Remove the copying of FL.sh. Relevant changes have been updated in TBar repo. See [4dea1ee](https://github.com/Marti2203/TBar/commit/4dea1eec8500483bf9d99ad90015e4c4a310b9b0)
      fixes #182 (`Updated FL.sh to take class paths from driver instead of hardcoded path`)

