### PR TITLE
Remove requirements for having tests in benchmark

### DIFF
--- a/app/drivers/benchmarks/AbstractBenchmark.py
+++ b/app/drivers/benchmarks/AbstractBenchmark.py
@@ -136,8 +136,8 @@ class AbstractBenchmark(AbstractDriver):
     @staticmethod
     def process_metadata(data):
         for experiment_item in data:
-            passing_list = experiment_item[AbstractBenchmark.key_passing_tests]
-            failing_list = experiment_item[AbstractBenchmark.key_failing_tests]
+            passing_list = experiment_item.get(AbstractBenchmark.key_passing_tests, [])
+            failing_list = experiment_item.get(AbstractBenchmark.key_failing_tests, [])
             passing_list_str = [f"{x}" for x in passing_list]
             failing_list_str = [f"{x}" for x in failing_list]
             experiment_item[AbstractBenchmark.key_passing_tests] = passing_list_str

--- a/app/drivers/tools/repair/AbstractRepairTool.py
+++ b/app/drivers/tools/repair/AbstractRepairTool.py
@@ -119,7 +119,7 @@ class AbstractRepairTool(AbstractTool):
             definitions.KEY_COUNT_POS,
         ]
         for k in interested_keys:
-            filtered_bug_info[k] = bug_info[k]
+            filtered_bug_info[k] = bug_info.get(k, None)
         repair_config_info["container-id"] = self.container_id
         self.stats.bug_info = filtered_bug_info
         self.stats.config_info = repair_config_info


### PR DESCRIPTION
Some benchmarks do not have tests. Previously cerberus would crash on benchmark without tests. This PR fixes it.