### PR TITLE
Added timestamp arg in GeneralConfig and fixed a typo

### DIFF
--- a/app/core/args.py
+++ b/app/core/args.py
@@ -119,7 +119,7 @@ def parse_args() -> Namespace:
     optional.add_argument(
         definitions.KEY_TIMESTAMP,
         help="Add timestamp before every command",
-        acton="store_true",
+        action="store_true",
         default=False,
     )
 

--- a/app/core/configs/general/GeneralConfig.py
+++ b/app/core/configs/general/GeneralConfig.py
@@ -7,6 +7,7 @@ class GeneralConfig:
         secure_hash: bool,
         cpus: int,
         gpus: int,
+        timestamp: bool,
     ):
 
         # validate config
@@ -16,6 +17,7 @@ class GeneralConfig:
         self.secure_hash = secure_hash
         self.cpus = cpus
         self.gpus = gpus
+        self.timestamp = timestamp
 
     def __str__(self) -> str:
         return (


### PR DESCRIPTION
b9fb4caf87414632e744f068781482ccd915f96d introduced, both, a typo when adding "timestamp" to the options. Also, even though passed via `ConfigDataFactory.create._create_general_config`, timestamp arg wasn't added to GeneralConfig.py